### PR TITLE
remove NFS rsize/wsize options from default

### DIFF
--- a/defaults/initrd.defaults
+++ b/defaults/initrd.defaults
@@ -81,7 +81,7 @@ overlayfs_modules_dir=mnt/cdrom
 
 LOOPS='/livecd.loop /zisofs /livecd.squashfs /image.squashfs /livecd.gcloop'
 
-DEFAULT_NFSOPTIONS="ro,nolock,rsize=1024,wsize=1024"
+DEFAULT_NFSOPTIONS="ro,nolock"
 
 # HWOPTS is the list of ALL options that take do/no prefixes, almost all of
 # which match a MODULES_* variable; it is ALSO the order of evaluation.


### PR DESCRIPTION
I suggest to completely remove "rsize=1024,wsize=1024" from the DEFAULT_NFSOPTIONS:
* The kernel/mount default is "unlimited" and the concrete values will be with negotiated with the NFS server.
* If optional values for {r,w}size are passed to the kernel commandline parameter "nfrsoot=...,<options>", this additinal options are *appended* to the resulting mount options. But (at least) for {r,w}size, the first occurrence strikes; i.e. the values passed via the commandline are ignored in fact.

As a more complex alternative, the function "findnfsmount()" (@ initrd.scripts, 569ff.) may be rewritten to parse and kick out double-occurences of options.

Background: I run into this issue booting a diskless server; using PXE for the kernel and initramfs and NFS for the rootfs.

Signed-off-by: Guido Jäkel <G.Jaekel@DNB.DE>