### PR TITLE
Fix and improve remote LUKS decryption

### DIFF
--- a/defaults/initrd.defaults
+++ b/defaults/initrd.defaults
@@ -52,7 +52,7 @@ KMINOR=`echo $KV | cut -f2 -d.`
 KVER="${KMAJOR}.${KMINOR}"
 MISCOPTS='debug detect'
 
-QUIET='1'
+QUIET=''
 ROOT_LINKS='bin sbin lib lib32 lib64 boot usr opt emul'
 ROOT_TREES='etc root home var'
 

--- a/defaults/initrd.scripts
+++ b/defaults/initrd.scripts
@@ -1472,12 +1472,12 @@ startLUKS() {
 		/sbin/ifconfig $(echo "${IP}" | awk -F":" '{print $6}' ) 0.0.0.0
 	fi
 
-	if [ -e /root.decrypted ]; then
-		rm /root.decrypted
+	if [ -e /ROOT.decrypted ]; then
+		rm /ROOT.decrypted
 	fi
 
-	if [ -e /swap.decrypted ]; then
-		rm /swap.decrypted
+	if [ -e /SWAP.decrypted ]; then
+		rm /SWAP.decrypted
 	fi
 }
 

--- a/defaults/initrd.scripts
+++ b/defaults/initrd.scripts
@@ -1295,8 +1295,12 @@ openLUKS() {
 	while [ 1 ]
 	do
 		local gpg_cmd=""
+		if [ -e ${flag_opened} ]
+		then
+			good_msg "The LUKS device ${LUKS_DEVICE} meanwhile was opened by someone else."
+			break
 		# if crypt_silent=1 and some error occurs, enter shell quietly
-		if [ \( ${CRYPT_SILENT} -eq 1 \) -a \( \( \( ${DEV_ERROR} -eq 1 \) -o \( ${KEY_ERROR} -eq 1 \) \) -o \( ${KEYDEV_ERROR} -eq 1 \) \) ]
+		elif [ \( ${CRYPT_SILENT} -eq 1 \) -a \( \( \( ${DEV_ERROR} -eq 1 \) -o \( ${KEY_ERROR} -eq 1 \) \) -o \( ${KEYDEV_ERROR} -eq 1 \) \) ]
 		then
 			run_shell
 		elif [ ${DEV_ERROR} -eq 1 ]
@@ -1311,10 +1315,6 @@ openLUKS() {
 		then
 			prompt_user "LUKS_KEYDEV" "${LUKS_NAME} key device"
 			KEYDEV_ERROR=0
-		elif [ -e ${flag_opened} ]
-		then
-			good_msg "The LUKS device ${LUKS_DEVICE} meanwhile was opened by someone else."
-			break
 		else
 			LUKS_DEVICE=$(find_real_device "${LUKS_DEVICE}")
 

--- a/defaults/login-remote.sh
+++ b/defaults/login-remote.sh
@@ -77,20 +77,20 @@ openLUKSremote() {
 					# 1st try: unencrypted keyfile
 					crypt_filter "cryptsetup ${cryptsetup_options} --key-file ${LUKS_KEY} luksOpen ${LUKS_DEVICE} ${LUKS_NAME}"
 					crypt_filter_ret=$?
+				fi
 
-					if [ -f /sbin/gpg ] && [ ${crypt_filter_ret} -ne 0 ]
-					then
-						# 2nd try: gpg-encrypted keyfile
-						[ -e /dev/tty ] && mv /dev/tty /dev/tty.org
-						mknod /dev/tty c 5 1
-						gpg_cmd="/sbin/gpg --logger-file /dev/null --quiet --decrypt ${LUKS_KEY} |"
-						crypt_filter "${gpg_cmd}cryptsetup ${cryptsetup_options} --key-file ${LUKS_KEY} luksOpen ${LUKS_DEVICE} ${LUKS_NAME}"
-						crypt_filter_ret=$?
+				if [ -f /sbin/gpg ] && [ ${crypt_filter_ret} -ne 0 ]
+				then
+					# 2nd try: gpg-encrypted keyfile
+					[ -e /dev/tty ] && mv /dev/tty /dev/tty.org
+					mknod /dev/tty c 5 1
+					gpg_cmd="/sbin/gpg --logger-file /dev/null --quiet --decrypt ${LUKS_KEY} |"
+					crypt_filter "${gpg_cmd}cryptsetup ${cryptsetup_options} --key-file ${LUKS_KEY} luksOpen ${LUKS_DEVICE} ${LUKS_NAME}"
+					crypt_filter_ret=$?
 
-						[ -e /dev/tty.org ] \
-							&& rm -f /dev/tty \
-							&& mv /dev/tty.org /dev/tty
-					fi
+					[ -e /dev/tty.org ] \
+						&& rm -f /dev/tty \
+						&& mv /dev/tty.org /dev/tty
 				fi
 
 				if [ ${crypt_filter_ret} -eq 0 ]

--- a/defaults/login-remote.sh
+++ b/defaults/login-remote.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# vim: set noexpandtab:
 
 . /etc/login-remote.conf
 . /etc/initrd.defaults

--- a/defaults/login-remote.sh
+++ b/defaults/login-remote.sh
@@ -93,6 +93,13 @@ openLUKSremote() {
 						&& mv /dev/tty.org /dev/tty
 				fi
 
+				if [ ${crypt_filter_ret} -ne 0 ]
+				then
+					# 3rd try: user-submitted passphrase
+					crypt_filter "cryptsetup ${cryptsetup_options} luksOpen ${LUKS_DEVICE} ${LUKS_NAME}"
+					crypt_filter_ret=$?
+				fi
+
 				if [ ${crypt_filter_ret} -eq 0 ]
 				then
 					touch ${flag_opened}

--- a/defaults/login-remote.sh
+++ b/defaults/login-remote.sh
@@ -104,6 +104,9 @@ openLUKSremote() {
 				then
 					touch ${flag_opened}
 					good_msg "LUKS device ${LUKS_DEVICE} opened" ${CRYPT_SILENT}
+					# Kill the cryptsetup process started by init
+					# so that the boot process can continue
+					killall cryptsetup
 					break
 				else
 					bad_msg "Failed to open LUKS device ${LUKS_DEVICE}" ${CRYPT_SILENT}

--- a/defaults/login-remote.sh
+++ b/defaults/login-remote.sh
@@ -45,8 +45,6 @@ openLUKSremote() {
 	while [ 1 ]
 	do
 		local gpg_cmd="" crypt_filter_ret=42
-		echo $-
-		sleep 1
 
 		if [ -e ${flag_opened} ]
 		then

--- a/defaults/login-remote.sh
+++ b/defaults/login-remote.sh
@@ -78,7 +78,7 @@ openLUKSremote() {
 					crypt_filter "cryptsetup ${cryptsetup_options} --key-file ${LUKS_KEY} luksOpen ${LUKS_DEVICE} ${LUKS_NAME}"
 					crypt_filter_ret=$?
 
-					if [ ${crypt_filter_ret} -ne 0 ]
+					if [ -f /sbin/gpg ] && [ ${crypt_filter_ret} -ne 0 ]
 					then
 						# 2nd try: gpg-encrypted keyfile
 						[ -e /dev/tty ] && mv /dev/tty /dev/tty.org


### PR DESCRIPTION
Hello,
Currently, the SSH parameter more or less works and allows genkernel to run dropbear at boot.
It was introduced in https://github.com/gentoo/genkernel/commit/11a3470508a6475a5fee00f26ccbd7a98b4f9e01 (initially submitted [here](https://bugs.gentoo.org/440126#c2)).

However, using it means following a rather complex procedure which is not documented anywhere:
* first, you need to SSH into the server, sending it the `post root` or `post swap` command and writing the passphrase to stdin, this means that it may be printed on the terminal
 * then you need to SSH a second time without calling any command, the device will then be decrypted by the login script

The problem is that even once the device has been decrypted, the boot process is still hanging because cryptsetup from init is running! I guess that the timeout which is present here:
https://github.com/gentoo/genkernel/blob/febc1b12b5b393e918da94b9f1c029f2adcea215/defaults/initrd.scripts#L865
was added to avoid this but it serves no purpose as cryptsetup itself never times out.
Once the device has been opened, it's not even possible to open a shell via SSH as the login-remote.sh script returns immediately, which means that we are now locked out…



I've become quite frustrated with the current state of things so I attempted to fix the blocking problem by killing all cryptsetup processes (I hope this is a clean enough solution) and adding an option to simply pass the key to cryptsetup's stdin when SSH'ing into the server.  This is what [dracut-crypt-ssh](https://github.com/dracut-crypt-ssh/dracut-crypt-ssh) does and what most users want to do anyway.

I've split the changes into many commits, some of which are cosmetic fixes. I haven't touched the documentation, which could be a good thing since `Add SSH support` is not very verbose.