### PR TITLE
gkbuilds/expat: add --without-docbook to src_configure

### DIFF
--- a/gkbuilds/expat.gkbuild
+++ b/gkbuilds/expat.gkbuild
@@ -4,6 +4,7 @@
 src_configure() {
 	local myconf=(
 		--enable-static
+		--without-docbook
 	)
 
 	gkconf "${myconf[@]}"


### PR DESCRIPTION
Signed-off-by: Stefan Strogin <steils@gentoo.org>