### PR TITLE
Disable unnecessary udev timeout in zpool import

### DIFF
--- a/defaults/initrd.scripts
+++ b/defaults/initrd.scripts
@@ -1630,6 +1630,7 @@ start_volumes() {
 
 	if [ "${USE_ZFS}" = '1' ]
 	then
+		export ZPOOL_IMPORT_UDEV_TIMEOUT_MS=0
 		# Avoid race involving asynchronous module loading
 		if call_func_timeout waitForZFS 5
 		then
@@ -1679,6 +1680,7 @@ start_volumes() {
 				fi
 			fi
 		fi
+		unset ZPOOL_IMPORT_UDEV_TIMEOUT_MS
 	fi
 }
 

--- a/defaults/linuxrc
+++ b/defaults/linuxrc
@@ -128,7 +128,6 @@ do
 		;;
 		dozfs*)
 			USE_ZFS=1
-			export ZPOOL_IMPORT_UDEV_TIMEOUT_MS=0
 
 			case "${x#*=}" in
 				*force*)


### PR DESCRIPTION
This is a regression that was introduced in sys-fs/zfs-kmod-0.7.0.
It was originally fixed by 2eb1d04, but
this neglected to handle the case where booting is done via arguments
such as "root=ZFS" or "root=ZFS=rpool/ROOT/gentoo" on the kernel
commandline. This handles it.

Signed-off-by: Richard Yao <ryao@gentoo.org>