### PR TITLE
gen_funcs.sh: fixed disk space check with non-English locale

### DIFF
--- a/gen_funcs.sh
+++ b/gen_funcs.sh
@@ -1853,7 +1853,7 @@ check_disk_space_requirements() {
 			gen_die "--check-free-disk-space-bootdir value '${CHECK_FREE_DISK_SPACE_BOOTDIR}' is not a valid number!"
 		fi
 
-		available_free_disk_space=$(unset POSIXLY_CORRECT && df -BM "${BOOTDIR}" | awk '$3 ~ /[0-9]+/ { print $4 }')
+		available_free_disk_space=$(unset POSIXLY_CORRECT && df -BM --output=avail "${BOOTDIR}" | sed -nEe '2s|^[^0-9]*([0-9]*).*$|\1|p' - )
 		if [ -n "${available_free_disk_space}" ]
 		then
 			print_info 2 '' 1 0
@@ -1890,7 +1890,7 @@ check_disk_space_requirements() {
 			gen_die "--check-free-disk-space-kerneloutputdir value '${CHECK_FREE_DISK_SPACE_KERNELOUTPUTDIR}' is not a valid number!"
 		fi
 
-		available_free_disk_space=$(unset POSIXLY_CORRECT && df -BM "${KERNEL_OUTPUTDIR}" | awk '$3 ~ /[0-9]+/ { print $4 }')
+		available_free_disk_space=$(unset POSIXLY_CORRECT && df -BM --output=avail "${KERNEL_OUTPUTDIR}" | sed -nEe '2s|^[^0-9]*([0-9]*).*$|\1|p' - )
 		if [ -n "${available_free_disk_space}" ]
 		then
 			print_info 2 '' 1 0


### PR DESCRIPTION
Currently genkernel always shows some error when any disk space checks are set and locale is not English (ru_RU.UTF-8 for example).