### PR TITLE
gen_determineargs.sh: removed duplicated config override for BUSYBOX_CONFIG

### DIFF
--- a/gen_determineargs.sh
+++ b/gen_determineargs.sh
@@ -415,7 +415,6 @@ determine_real_args() {
 	set_config_with_override BOOL   GENZIMAGE                             CMD_GENZIMAGE                             "no"
 	set_config_with_override BOOL   KEYMAP                                CMD_KEYMAP                                "yes"
 	set_config_with_override BOOL   DOKEYMAPAUTO                          CMD_DOKEYMAPAUTO                          "no"
-	set_config_with_override STRING BUSYBOX_CONFIG                        CMD_BUSYBOX_CONFIG
 	set_config_with_override STRING STRIP_TYPE                            CMD_STRIP_TYPE                            "modules"
 	set_config_with_override BOOL   INSTALL                               CMD_INSTALL                               "yes"
 	set_config_with_override BOOL   CLEANUP                               CMD_CLEANUP                               "yes"


### PR DESCRIPTION
The same line is already exist next to "BUSYBOX" var.