### PR TITLE
initrd.scripts: fs_type_in_use() simplification

### DIFF
--- a/defaults/initrd.scripts
+++ b/defaults/initrd.scripts
@@ -1059,8 +1059,7 @@ run_shell() {
 }
 
 fs_type_in_use() {
-	fs_type=$1
-	cut -d ' ' -f 3 < /proc/mounts | grep -Fq "${fs_type}"
+	grep -Eqse "^[^ ]+ [^ ]+ ${1} " /proc/mounts
 }
 
 mount_devfs() {


### PR DESCRIPTION
One more simplification and speed-up.
When processing the file directly grep could exit at the first match, without processing the whole stream.