### PR TITLE
initrd.scripts: mount_devfs: check whether devtmpfs is mounted on /dev

### DIFF
--- a/defaults/initrd.scripts
+++ b/defaults/initrd.scripts
@@ -1074,7 +1074,7 @@ mount_devfs() {
 	fi
 
 	# Options copied from /etc/init.d/udev-mount, should probably be kept in sync
-	if ! fs_type_in_use devtmpfs
+	if ! grep -Eqse "^[^ ]+ /dev ${devfs} " /proc/mounts
 	then
 		run mount -t ${devfs} -o "exec,nosuid,mode=0755,size=10M" udev /dev \
 			|| bad_msg "Failed to mount /dev as ${devfs}"


### PR DESCRIPTION
If tmpfs is used for /dev, it is not enough to check whether tmpfs is mounted somewhere as it could be used for other reasons.
Also ensure that devtmpfs is mounted at the right mountpoint (/dev) and not somewhere else.