### PR TITLE
Add support for Plymouth boot splash

### DIFF
--- a/defaults/initrd.scripts
+++ b/defaults/initrd.scripts
@@ -1031,6 +1031,8 @@ run_emergency_shell() {
 }
 
 run_shell() {
+	splash 'verbose' >/dev/null &
+
 	if ! is_userinteraction_allowed
 	then
 		bad_msg "gk.userinteraction.disabled is set; Spawning a shell is disabled!"
@@ -1226,9 +1228,22 @@ write_env_file() {
 }
 
 crypt_filter() {
+	local ask_pass=${2}
+	good_msg "Using the following decryption command: ${1}" ${CRYPT_SILENT}
+
 	if [ "${CRYPT_SILENT}" = '1' ]
 	then
 		eval run ${1}
+	elif [ "${PLYMOUTH}" = '1' ] && [ ${ask_pass} -eq 1 ]
+	then
+		local ply_cmd_file="$(mktemp -t 'ply_cmd.XXXXXX' 2>/dev/null)"
+		printf '#!/bin/sh\n%s\n' "${1}" > "${ply_cmd_file}"
+		run chmod 500 "${ply_cmd_file}"
+		plymouthRun ask-for-password --prompt "Enter LUKS passphrase" \
+			--number-of-tries=3 --command="${ply_cmd_file}"
+		res=$?
+		run rm "${ply_cmd_file}" >/dev/null 2>&1
+		return ${res}
 	else
 		splash 'verbose' >/dev/null &
 		eval run ${1}
@@ -1306,6 +1321,7 @@ prompt_user() {
 	fi
 	[ -n "${3}" ] && local explnt=" or : ${3}" || local explnt="."
 
+	splash 'verbose' >/dev/null &
 	bad_msg "Could not find the ${2} in ${oldvalue}${explnt}"
 
 	if [ -f "${GK_USERINTERACTION_DISABLED_STATEFILE}" ]
@@ -1388,6 +1404,8 @@ prompt_user() {
 			eval ${1}'='${oldvalue}
 			;;
 	esac
+
+	splash 'quiet' >/dev/null &
 }
 
 cmdline_hwopts() {
@@ -1550,7 +1568,64 @@ copyKeymap() {
 }
 
 splash() {
-	return 0
+	if [ "${FBSPLASH}" = '1' ]
+	then
+		return 0
+	elif [ "${PLYMOUTH}" = '1' ]
+	then
+		case "${1}" in
+			init)
+			plymouthInit
+			;;
+
+			verbose)
+			plymouthRun --hide-splash
+			;;
+
+			set_msg)
+			plymouthRun --update="${2}"
+			;;
+
+			quiet)
+			plymouthRun --show-splash
+			;;
+
+			hasroot)
+			plymouthRun --newroot="${2}"
+			;;
+		esac
+	fi
+}
+
+plymouthRun() {
+	run plymouth --ping 2>/dev/null || return $?
+	run plymouth "${@}" 2>/dev/null
+}
+
+plymouthInit() {
+	good_msg "Starting Plymouth..."
+	run mkdir -p -m 0755 /run/plymouth || return 1
+
+	# Make sure that udev is done loading tty and drm
+	run udevadm trigger --action=add --attr-match=class=0x030000 >/dev/null 2>&1
+	run udevadm trigger --action=add --subsystem-match=graphics \
+		--subsystem-match=drm --subsystem-match=tty >/dev/null 2>&1
+	udevsettle
+
+	run plymouthd --mode=boot --attach-to-session \
+		--pid-file=/run/plymouth/pid
+	if [ $? -ne 0 ]
+	then
+		bad_msg "Can't start plymouthd!"
+		PLYMOUTH=0
+		return 1
+	fi
+
+	plymouthRun --show-splash
+	if [ $? -eq 0 ]
+	then
+		good_msg "Plymouth initialized"
+	fi
 }
 
 start_volumes() {
@@ -1825,6 +1900,7 @@ openLUKS() {
 	eval local LUKS_KEYDEV='"${CRYPT_'${TYPE}'_KEYDEV}"'
 	eval local LUKS_KEYDEV_FSTYPE='"${CRYPT_'${TYPE}'_KEYDEV_FSTYPE}"'
 	eval local OPENED_LOCKFILE='"${CRYPT_'${TYPE}'_OPENED_LOCKFILE}"'
+	local ASK_PASS=0
 	local DEV_ERROR=0
 	local HEADER_ERROR=0 HEADERDEV_ERROR=0
 	local KEY_ERROR=0 KEYDEV_ERROR=0
@@ -2054,12 +2130,25 @@ openLUKS() {
 					else
 						[ -e /dev/tty ] && run mv /dev/tty /dev/tty.org
 						run mknod /dev/tty c 5 1
+						ASK_PASS=1
 						cryptsetup_options="${cryptsetup_options} -d -"
-						gpg_cmd="gpg --logger-file /dev/null --quiet --decrypt ${mntkey}${LUKS_KEY} |"
+						gpg_cmd="gpg --logger-file /dev/null --quiet"
+						# plymouth password entry is passed through STDIN, requiring '--passphrase-fd 0 --batch'
+						# for newer gpg versions (>=2.1) '--pinentry-mode loopback' may also be required for the above
+						# '--no-tty' is included to prevent interruption of plymouth by any gpg output
+						if [ "${PLYMOUTH}" = '1' -a "${CRYPT_SILENT}" != '1' ]
+						then
+							gpg_cmd="${gpg_cmd} --passphrase-fd 0 --batch --no-tty --decrypt ${mntkey}${LUKS_KEY} | "
+						else
+							gpg_cmd="${gpg_cmd} --decrypt ${mntkey}${LUKS_KEY} | "
+						fi
 					fi
 				else
 					cryptsetup_options="${cryptsetup_options} -d ${mntkey}${LUKS_KEY}"
 				fi
+			else
+				# no keyfile defined, password is required
+				ASK_PASS=1
 			fi
 
 			if [ -n "${cryptsetup_options}" ]
@@ -2068,7 +2157,7 @@ openLUKS() {
 			fi
 
 			# At this point, {header,key}file or not, we're ready!
-			crypt_filter "${gpg_cmd}cryptsetup ${cryptsetup_options} luksOpen ${LUKS_DEVICE} ${LUKS_NAME}"
+			crypt_filter "${gpg_cmd}cryptsetup ${cryptsetup_options} luksOpen ${LUKS_DEVICE} ${LUKS_NAME}" "${ASK_PASS}"
 			crypt_filter_ret=$?
 
 			[ -e /dev/tty.org ] \

--- a/defaults/linuxrc
+++ b/defaults/linuxrc
@@ -163,6 +163,18 @@ do
 			MLIST=$(echo ${MLIST} ${x#*=} | sed -e 's/^\ *//;s/,/ /g')
 			export MLIST
 		;;
+		splash)
+			if [ -x /usr/bin/plymouth -a -x /usr/sbin/plymouthd ]
+			then
+				PLYMOUTH=1
+			fi
+		;;
+		splash=*)
+			if [ -e /etc/initrd.splash ]
+			then
+				FBSPLASH=1
+			fi
+		;;
 		# /dev/md
 		lvmraid=*)
 			warn_msg "'${x}' kernel command-line argument is deprecated; Use 'dolvm' instead!"
@@ -557,8 +569,6 @@ then
 	FIRSTMODS="${FIRSTMODS} btrfs"
 fi
 
-splash 'init'
-
 cmdline_hwopts
 
 # Mount devfs
@@ -635,6 +645,9 @@ else
 fi
 
 cd /
+
+# start splash; plymouth must start after udev
+splash 'init'
 
 # Start iSCSI
 if hash iscsistart >/dev/null 2>&1
@@ -1335,6 +1348,8 @@ keyctl_keyremove
 
 # Re-run to ensure $NEWROOT/etc/initramfs.mounts was processed at least once
 process_initramfs_mounts
+
+splash 'hasroot' "${NEW_ROOT}"
 
 # Execute script on the cdrom just before boot to update things if necessary
 cdupdate

--- a/doc/genkernel.8.txt
+++ b/doc/genkernel.8.txt
@@ -359,6 +359,13 @@ INITIALIZATION
     <theme>  rather than the default theme specified in your splash
     configuration. If *--no-splash* is specified, then splash is disabled.
 
+*--*[*no-*]*plymouth*::
+    Includes or excludes Plymouth from the initramfs. If "splash" is
+    passed at boot, Plymouth will be activated.
+
+*--plymouth-theme*=<theme>::
+    Embeds the given Plymouth theme into the initramfs.
+
 *--do-keymap-auto*::
     Force keymap selection at boot.
 

--- a/gen_cmdline.sh
+++ b/gen_cmdline.sh
@@ -53,6 +53,8 @@ longusage() {
   echo "	--no-mrproper		Do not run 'make mrproper' before compilation"
   echo "	--splash		Install framebuffer splash support into initramfs"
   echo "	--no-splash		Do not install framebuffer splash"
+  echo "	--plymouth		Enable Plymouth support"
+  echo "	--no-plymouth		Do not enable Plymouth support"
   echo "	--install		Install the kernel after building"
   echo "	--no-install		Do not install the kernel after building"
   echo "	--symlink		Manage symlinks in /boot for installed images"
@@ -127,6 +129,7 @@ longusage() {
   echo "	--splash-res=<res>	Select splash theme resolutions to install"
   echo "	--splash=<theme>	Enable framebuffer splash using <theme>"
   echo "	--splash-res=<res>	Select splash theme resolutions to install"
+  echo "	--plymouth-theme=<theme>    Embed the given Plymouth theme"
   echo "	--do-keymap-auto	Forces keymap selection at boot"
   echo "	--keymap		Enables keymap selection support"
   echo "	--no-keymap		Disables keymap selection support"
@@ -671,6 +674,17 @@ parse_cmdline() {
 		--splash-res=*)
 			SPLASH_RES="${*#*=}"
 			print_info 3 "SPLASH_RES: ${SPLASH_RES}"
+			;;
+		--plymouth)
+			CMD_PLYMOUTH="yes"
+			PLYMOUTH_THEME='text'
+			print_info 3 "CMD_PLYMOUTH: ${CMD_PLYMOUTH}"
+			;;
+		--plymouth-theme=*)
+			CMD_PLYMOUTH="yes"
+			PLYMOUTH_THEME="${*#*=}"
+			print_info 3 "CMD_PLYMOUTH: ${CMD_PLYMOUTH}"
+			print_info 3 "PLYMOUTH_THEME: ${PLYMOUTH_THEME}"
 			;;
 		--install|--no-install)
 			CMD_INSTALL=$(parse_optbool "$*")

--- a/gen_determineargs.sh
+++ b/gen_determineargs.sh
@@ -1028,12 +1028,12 @@ determine_real_args() {
 
 		if isTrue "${PLYMOUTH}" && ! isTrue "${FIRMWARE}"
 		then
-			gen_die "--plymouth requires --firmware but --no-firmware is set!"
+			print_warning 3 "--plymouth potentially requires graphics firmware to function! Please configure your --firmware flags appropriately!"
 		fi
 
 		if isTrue "${PLYMOUTH}" && ! isTrue "${ALLRAMDISKMODULES}"
 		then
-			gen_die "--plymouth requires --all-ramdisk-modules but --no-all-ramdisk-modules is set!"
+			print_warning 3 "--plymouth potentially requires DRM kernel modules to function! Please configure your --ramdisk-modules flags appropriately!"
 		fi
 
 		if isTrue "${SSH}"

--- a/gen_determineargs.sh
+++ b/gen_determineargs.sh
@@ -387,6 +387,7 @@ determine_real_args() {
 	set_config_with_override STRING MODPROBEDIR                           CMD_MODPROBEDIR                           "/etc/modprobe.d"
 
 	set_config_with_override BOOL   SPLASH                                CMD_SPLASH                                "no"
+	set_config_with_override BOOL   PLYMOUTH                              CMD_PLYMOUTH                              "no"
 	set_config_with_override BOOL   CLEAR_CACHEDIR                        CMD_CLEAR_CACHEDIR                        "no"
 	set_config_with_override BOOL   POSTCLEAR                             CMD_POSTCLEAR                             "no"
 	set_config_with_override BOOL   MRPROPER                              CMD_MRPROPER                              "yes"
@@ -1018,6 +1019,21 @@ determine_real_args() {
 			then
 				gen_die "splash_geninitramfs is required for --splash but was not found!"
 			fi
+		fi
+
+		if isTrue "${PLYMOUTH}" && isTrue "${SPLASH}"
+		then
+			gen_die "--plymouth and --splash are mutually exclusive!"
+		fi
+
+		if isTrue "${PLYMOUTH}" && ! isTrue "${FIRMWARE}"
+		then
+			gen_die "--plymouth requires --firmware but --no-firmware is set!"
+		fi
+
+		if isTrue "${PLYMOUTH}" && ! isTrue "${ALLRAMDISKMODULES}"
+		then
+			gen_die "--plymouth requires --all-ramdisk-modules but --no-all-ramdisk-modules is set!"
 		fi
 
 		if isTrue "${SSH}"

--- a/genkernel.conf
+++ b/genkernel.conf
@@ -174,6 +174,13 @@ NOCOLOR="false"
 # This supersedes the "SPLASH_THEME" option in '/etc/conf.d/splash'.
 #SPLASH_THEME="gentoo"
 
+# Includes or excludes Plymouth from the initramfs. If "splash" is
+# passed at boot, Plymouth will be activated.
+#PLYMOUTH="no"
+
+# Embeds the given plymouth theme in the initramfs.
+#PLYMOUTH_THEME="text"
+
 # Run "emerge @module-rebuild" automatically when possible and necessary
 # after kernel and modules have been compiled
 #MODULEREBUILD="yes"


### PR DESCRIPTION
Since udev is now included by default when using genkernel, adding support for Plymouth wasn't too difficult.  As far as I can tell, this was also the last major feature that genkernel-next supported that genkernel does not.

I tested it out on my system (following Sakaki's EFI Guide) and it appears to work just fine!

I followed gk-next as a guidline when writing this, but everything has been coded from scratch.  If there is anything that needs changing please let me know.