### PR TITLE
gkbuild: Install the correct binaries with slibtool

### DIFF
--- a/gen_funcs.sh
+++ b/gen_funcs.sh
@@ -1974,6 +1974,29 @@ check_distfiles() {
 	fi
 }
 
+# @FUNCTION: install_exe
+# @USAGE: <file> <destination>
+# @DESCRIPTION:
+# Finds an executable binary file and installs it in cases where there may be
+# similarly named shell wrapper scripts. This happens when GNU libtool creates
+# an executable named 'foo' while slibtool creates '.libs/foo' and 'foo' is a
+# shell script that should not be installed.
+install_exe() {
+	local file="${1##*/}"
+	local dest="${2}"
+
+	local dir
+	[[ "${1%/*}" == "${file}" ]] || dir="${1%/*}/"
+
+	[[ -f "${dir}${file}" ]] || gen_die "File '${dir}${file}' does not exist!"
+
+	# Ensure only the binaries are installed and not a similarly named wrapper script
+	find "${S}/${dir}" -type f -name "${file}" -print0 |
+		xargs -0 file | grep executable | grep ELF | cut -f 1 -d : |
+		xargs -I '{}' cp -a '{}' "${dest}" ||
+		gen_die "Failed to copy '${S}/${dir}${file}' to '${dest}'!"
+}
+
 # @FUNCTION: expand_file
 # @USAGE: <file>
 # @DESCRIPTION:

--- a/gkbuilds/cryptsetup.gkbuild
+++ b/gkbuilds/cryptsetup.gkbuild
@@ -34,8 +34,7 @@ src_install() {
 		"${D}"/sbin/* \
 		"${D}"/usr/share/
 
-	cp -a cryptsetup.static "${D}"/sbin/cryptsetup \
-		|| die "Failed to copy '${S}/cryptsetup.static' to '${D}/sbin/cryptsetup'!"
+	install_exe 'cryptsetup.static' "${D}"/sbin/cryptsetup
 
 	"${STRIP}" --strip-all "${D}"/sbin/cryptsetup \
 		|| die "Failed to strip '${D}/sbin/cryptsetup'!"

--- a/gkbuilds/util-linux.gkbuild
+++ b/gkbuilds/util-linux.gkbuild
@@ -47,11 +47,8 @@ src_install() {
 
 	mkdir "${D}"/sbin || die "Failed to create '${D}/sbin'!"
 
-	cp -a blkid.static "${D}"/sbin/blkid \
-		|| die "Failed to copy '${S}/blkid.static' to '${D}/sbin/blkid'!"
-
-	cp -a switch_root "${D}"/sbin/switch_root \
-		|| die "Failed to copy '${S}/switch_root' to '${D}/sbin/switch_root'!"
+	install_exe 'blkid.static' "${D}"/sbin/blkid
+	install_exe 'switch_root' "${D}"/sbin/switch_root
 
 	local sbin
 	for sbin in \


### PR DESCRIPTION
When using genkernel with `sys-devel/slibtool` rather than `sys-devel/libtool` some of the build scripts will install slibtool wrapper scripts instead of the correct binary executable files. This happens because they are installed manually rather than with the `install` target that correctly calls `$LIBTOOL`. This will then fail when `strip(1)` doesn't accept text files as input.

There is already a solution for this in `x11-apps/mesa-progs` in the gentoo repo which I adapted for `util-linux` here.

https://gitweb.gentoo.org/repo/gentoo.git/tree/x11-apps/mesa-progs/mesa-progs-9999.ebuild?id=cd699fd652dc322e78d74db341f56f9b6a3abd11#n65

This might need to be done in more places, but I decided to start with `util-linux` and `cryptsetup` which are failing for me currently.

Additionally to reproduce this issue genkernel needs to use slibtool instead of libtool which is not straight forward. To accomplish this I used the `--utils-make="$HOME"/bin/tools/make` argument for genkernel where `$HOME"/bin/tools/make` is the following short script.
```
#!/bin/sh

export MAKE='make LIBTOOL=rlibtool'
export MAKEFLAGS='LIBTOOL=rlibtool'

make "$@"
```