### PR TITLE
gen_initramfs.sh: append devicemanager only for dmraid, luks, or lvm

### DIFF
--- a/gen_funcs.sh
+++ b/gen_funcs.sh
@@ -22,6 +22,15 @@ isTrue() {
 	return 1
 }
 
+anyTrue() {
+	local x
+	for x
+	do
+		isTrue "${x}" && return 0
+	done
+	return 1
+}
+
 set_color_vars() {
 	if ! isTrue "${NOCOLOR}"
 	then

--- a/gen_initramfs.sh
+++ b/gen_initramfs.sh
@@ -2007,11 +2007,14 @@ append_auxiliary() {
 }
 
 append_data() {
-	local name=$1 var=$2
+	[ $# -eq 0 ] && gen_die "append_data() called with zero arguments"
+
+	local name=$1
 	local func="append_${name}"
 
-	[ $# -eq 0 ] && gen_die "append_data() called with zero arguments"
-	if [ $# -eq 1 ] || isTrue "${var}"
+	shift
+
+	if [ $# -eq 0 ] || anyTrue "$@"
 	then
 		print_info 1 "$(get_indent 1)>> Appending ${name} cpio data ..."
 		${func} || gen_die "${func}() failed!"
@@ -2037,7 +2040,7 @@ create_initramfs() {
 	append_data 'base_layout'
 	append_data 'util-linux'
 	append_data 'eudev'
-	append_data 'devicemanager'
+	append_data 'devicemanager' "${DMRAID}" "${LVM}" "${LUKS}" "${MULTIPATH}"
 	append_data 'auxiliary' "${BUSYBOX}"
 	append_data 'busybox' "${BUSYBOX}"
 	append_data 'b2sum' "${B2SUM}"


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/749957