### PR TITLE
Additional test to allow for hibernation resume...

### DIFF
--- a/defaults/linuxrc
+++ b/defaults/linuxrc
@@ -671,7 +671,8 @@ keyctl_keyadd
 if [ "${CDROOT}" != '1' ]
 then
 	if ( [ -n "${CRYPT_SWAP_KEY}" ] && [ -z "${CRYPT_SWAP_KEYDEV}" ] ) || \
-	   ( [ -n "${CRYPT_SWAP_HEADER}" ] && [ -z "${CRYPT_SWAP_HEADERDEV}" ] )
+	   ( [ -n "${CRYPT_SWAP_HEADER}" ] && [ -z "${CRYPT_SWAP_HEADERDEV}" ] ) || \
+	   ( [ "${REAL_ROOT}" = "${REAL_RESUME}" ] || [ ${USE_LVM_NORMAL} -eq 1 ] )
 	then
 		# the swap key or header might be on the root fs so start it first in this case
 		start_LUKS_root


### PR DESCRIPTION
...on a broader range of system configurations, including LVM and swapfiles.
This change allows for LVM or swapfile setups where root partion and resume partition are the same.
Does potentially require setting resume_offset kernel parameter for swapfiles.


See: https://github.com/gentoo/genkernel/pull/10#discussion_r883125275