### PR TITLE
Fixes a mistake with quotation usage when testing for LVM flag.

### DIFF
--- a/defaults/linuxrc
+++ b/defaults/linuxrc
@@ -672,7 +672,7 @@ if [ "${CDROOT}" != '1' ]
 then
 	if ( [ -n "${CRYPT_SWAP_KEY}" ] && [ -z "${CRYPT_SWAP_KEYDEV}" ] ) || \
 	   ( [ -n "${CRYPT_SWAP_HEADER}" ] && [ -z "${CRYPT_SWAP_HEADERDEV}" ] ) || \
-	   ( [ "${REAL_ROOT}" = "${REAL_RESUME}" ] || [ ${USE_LVM_NORMAL} -eq 1 ] )
+	   ( [ "${REAL_ROOT}" = "${REAL_RESUME}" ] || [ "${USE_LVM_NORMAL}" = '1' ] )
 	then
 		# the swap key or header might be on the root fs so start it first in this case
 		start_LUKS_root


### PR DESCRIPTION
See: https://github.com/gentoo/genkernel/pull/38#issuecomment-1140330118

I'd made a mistake on my test of the use_LVM _normal flag in my prior pull request.