### PR TITLE
Enable threaded XZ compression by default

### DIFF
--- a/defaults/compression_methods.sh
+++ b/defaults/compression_methods.sh
@@ -32,7 +32,7 @@ GKICM_LZMA_EXT=".lzma"
 GKICM_LZMA_PKG="app-arch/xz-utils"
 
 GKICM_XZ_KOPTNAME="XZ"
-GKICM_XZ_CMD="xz -e --check=none -z -f -9"
+GKICM_XZ_CMD="xz -e --check=none -z -f -9 -T 0"
 GKICM_XZ_EXT=".xz"
 GKICM_XZ_PKG="app-arch/xz-utils"
 


### PR DESCRIPTION
With the current proliferation of multi-core CPUs enabling threaded XZ compression brings very significant runtime improvement: on my 4-core system the total genkernel runtime drops from 356 seconds to 166 seconds (a reduction of more than 50%) - so let's enable this mode by default.
