### PR TITLE
enable bootconfig support in genkernel

### DIFF
--- a/defaults/linuxrc
+++ b/defaults/linuxrc
@@ -55,6 +55,7 @@ run busybox --install -s
 CMDLINE=$(cat /proc/cmdline 2>/dev/null)
 for x in ${CMDLINE}
 do
+	x=${x//\"/}
 	case "${x}" in
 		real_root=*)
 			REAL_ROOT=${x#*=}

--- a/gen_cmdline.sh
+++ b/gen_cmdline.sh
@@ -174,6 +174,9 @@ longusage() {
   echo "	--bootloader=(grub|grub2)"
   echo "				Add new kernel to GRUB (grub) or GRUB2 (grub2) bootloader"
   echo "	--no-bootloader		Skip bootloader update"
+  echo "	--bootconfig=(<file>|none)"
+  echo "				Append a kernel bootconfig data to initramfs"
+  echo "	--no-bootconfig		No append the kernel bootconfig to initramfs"
   echo "	--linuxrc=<file>	Specifies a user created linuxrc"
   echo "	--busybox-config=<file>	Specifies a user created busybox config"
   echo "	--genzimage		Make and install kernelz image (PowerPC)"
@@ -539,6 +542,16 @@ parse_cmdline() {
 		--no-bootloader)
 			CMD_BOOTLOADER="no"
 			print_info 3 "CMD_BOOTLOADER: ${CMD_BOOTLOADER}"
+			;;
+		--bootconfig=*)
+			CMD_BOOTCONFIG="yes"
+			BOOTCONFIG_FILE="${*#*=}"
+			[ -z "${BOOTCONFIG_FILE}" ] && CMD_BOOTCONFIG="no"
+			print_info 3 "CMD_BOOTCONFIG: ${BOOTCONFIG_FILE}"
+			;;
+		--no-bootconfig)
+			CMD_BOOTCONFIG="no"
+			print_info 3 "CMD_BOOTCONFIG=${CMD_BOOTCONFIG}"
 			;;
 		--iscsi|--no-iscsi)
 			CMD_ISCSI=$(parse_optbool "$*")

--- a/gen_determineargs.sh
+++ b/gen_determineargs.sh
@@ -422,6 +422,7 @@ determine_real_args() {
 	set_config_with_override BOOL   HYPERV                                CMD_HYPERV                                "no"
 	set_config_with_override STRING BOOTFONT                              CMD_BOOTFONT                              "none"
 	set_config_with_override STRING BOOTLOADER                            CMD_BOOTLOADER                            "no"
+	set_config_with_override BOOL   BOOTCONFIG                            CMD_BOOTCONFIG                            "no"
 	set_config_with_override BOOL   B2SUM                                 CMD_B2SUM                                 "no"
 	set_config_with_override BOOL   BUSYBOX                               CMD_BUSYBOX                               "yes"
 	set_config_with_override STRING BUSYBOX_CONFIG                        CMD_BUSYBOX_CONFIG
@@ -769,6 +770,18 @@ determine_real_args() {
 			gen_die "Invalid bootloader '${BOOTLOADER}'; --bootloader=<bootloader> requires one of: no, grub, grub2"
 			;;
 	esac
+
+	if isTrue "${BOOTCONFIG}"
+	then
+		BOOTCONFIG_FILE=$(expand_file "${BOOTCONFIG_FILE}")
+		if [ -z "${BOOTCONFIG_FILE}" ]
+		then
+			gen_die "--bootconfig value '${BOOTCONFIG_FILE}' failed to expand!"
+		elif [ ! -e "${BOOTCONFIG_FILE}" ]
+		then
+			gen_die "--bootconfig file '${BOOTCONFIG_FILE}' does not exist!"
+		fi
+	fi
 
 	if isTrue "${KERNEL_SOURCES}"
 	then

--- a/gen_initramfs.sh
+++ b/gen_initramfs.sh
@@ -2311,6 +2311,16 @@ create_initramfs() {
 			${mkimage_cmd} ${mkimage_args} -n "${GK_FILENAME_TEMP_INITRAMFS}" -d "${CPIO_ARCHIVE}" "${CPIO_ARCHIVE}.uboot" >> ${LOGFILE} 2>&1 || gen_die "Wrapping initramfs using mkimage failed"
 			mv -f "${CPIO_ARCHIVE}.uboot" "${CPIO_ARCHIVE}" || gen_die "Rename failed"
 		fi
+
+		if isTrue "${BOOTCONFIG}"
+		then
+			local bootconfig_cmd=$(type -p bootconfig)
+			[[ -z ${bootconfig_cmd} ]] && gen_die "bootconfig is not available. Please install package 'dev-util/bootconfig'."
+			local bootconfig_args="-a ${BOOTCONFIG_FILE}"
+			print_info 1 "$(get_indent 1)>> Appending bootconfig data ..."
+			print_info 2 "$(get_indent 1)${bootconfig_cmd} ${bootconfig_args} ${CPIO_ARCHIVE}"
+			${bootconfig_cmd} ${bootconfig_args} "${CPIO_ARCHIVE}" >> ${LOGFILE} 2>&1 || gen_die "Appending bootconfig data failed"
+		fi
 	fi
 
 	if isTrue "${CMD_INSTALL}"

--- a/genkernel.conf
+++ b/genkernel.conf
@@ -169,6 +169,9 @@ NOCOLOR="false"
 # Add boot splash using splashutils
 #SPLASH="no"
 
+# Append a bootconfig to the initramfs
+#BOOTCONFIG="no"
+
 # Use this splash theme. If commented out - the "default" name theme is used.
 # Also, SPLASH="yes" needs to be enabled for this one to work.
 # This supersedes the "SPLASH_THEME" option in '/etc/conf.d/splash'.


### PR DESCRIPTION
with this patch, we can make the genkernel appending bootconfig data when generating initramfs image

https://bugs.gentoo.org/852845