### PR TITLE
Fix s390x support

### DIFF
--- a/gen_arch.sh
+++ b/gen_arch.sh
@@ -26,6 +26,9 @@ determine_kernel_arch() {
 		riscv|riscv64*)
 			KERNEL_ARCH=riscv
 			;;
+		s390*)
+			KERNEL_ARCH=s390
+			;;
 		x86)
 			if [ "${VER}" -ge "3" ]
 			then


### PR DESCRIPTION
Make sure we pull in correct genkernel arch-specific configuration. Kernel arch is always "s390".