### PR TITLE
genkernel.conf: make section titles more consistent

### DIFF
--- a/genkernel.conf
+++ b/genkernel.conf
@@ -5,7 +5,7 @@
 # with the internal settings being least important, configuration file
 # settings next, and command line options being most important.
 
-# =========Common Command Line Option Defaults=========
+# =========COMMON COMMAND LINE OPTION DEFAULTS=========
 
 # Install to $BOOTDIR
 #INSTALL="yes"
@@ -185,7 +185,7 @@ NOCOLOR="false"
 #CMD_CALLBACK=""
 
 
-# =========Keymap Settings=========
+# =========KEYMAP SETTINGS=========
 #
 # Force keymap selection at boot
 #DOKEYMAPAUTO="no"
@@ -194,7 +194,7 @@ NOCOLOR="false"
 #KEYMAP="yes"
 
 
-# =========Low Level Compile Settings=========
+# =========LOW LEVEL COMPILE SETTINGS=========
 #
 # Assembler to use for the kernel.  See also the --kernel-as command line
 # option.
@@ -257,7 +257,7 @@ NOCOLOR="false"
 #KERNEL_BINARY_OVERRIDE="arch/foo/boot/bar"
 
 
-# =========GENKERNEL LOCATION CONFIGURATION============
+# =========GENKERNEL LOCATION CONFIGURATION=========
 #
 # Variables:
 #   %%ARCH%%  - Final determined architecture
@@ -285,7 +285,7 @@ LOGFILE="/var/log/genkernel.log"
 LOGLEVEL=1
 
 
-# =========COMPILED UTILS CONFIGURATION============
+# =========COMPILED UTILS CONFIGURATION=========
 #
 # Default location of kernel source
 DEFAULT_KERNEL_SOURCE="/usr/src/linux"
@@ -304,7 +304,7 @@ DEFAULT_KERNEL_SOURCE="/usr/src/linux"
 #   You can still override these settings in here.
 
 
-# =========MISC KERNEL CONFIGURATION============
+# =========MISC KERNEL CONFIGURATION=========
 #
 # Set kernel filename which will be used when kernel will be installed
 # into BOOTDIR. See man page to learn more about available placeholders.
@@ -339,7 +339,7 @@ DEFAULT_KERNEL_SOURCE="/usr/src/linux"
 #KERNEL_MODULES_PREFIX=""
 
 
-# =========MISC INITRAMFS CONFIGURATION============
+# =========MISC INITRAMFS CONFIGURATION=========
 #
 # Set initramfs filename which will be used when initramfs will be
 # installed into BOOTDIR. See man page to learn more about available
@@ -407,7 +407,7 @@ DEFAULT_KERNEL_SOURCE="/usr/src/linux"
 #NETBOOT="no"
 
 
-# =========MISC BOOT CONFIGURATION============
+# =========MISC BOOT CONFIGURATION=========
 #
 # Specify a default for real_root=
 #REAL_ROOT="/dev/one/two/gentoo"


### PR DESCRIPTION
by capitalizing all section titles and using the same amount of = characters.

Signed-off-by: Diego Viola <diego.viola@gmail.com>