### PR TITLE
Adds support to boot from a ISO image accessible over HTTP

### DIFF
--- a/defaults/initrd.defaults
+++ b/defaults/initrd.defaults
@@ -158,3 +158,8 @@ HWOPTS="keymap cache modules virtio hyperv ${HWOPTS_BLK} bcache lvm dmraid multi
 # This is the set of default HWOPTS, in the order that they are loaded.
 # This is whitespace aligned with HWOPTS above.
 MY_HWOPTS="          modules virtio hyperv ${HWOPTS_BLK}        lvm dmraid           mdadm     fs       crypto"
+
+# Defaults for HTTPBOOT option to allow mounting the iso locally
+ISO_PATH="/iso"
+ISO_NAME="/gentoo.iso"
+ISO_TEMP="${ISO_PATH}/temp"

--- a/defaults/linuxrc
+++ b/defaults/linuxrc
@@ -85,6 +85,10 @@ do
 		cdroot_marker=*)
 			CDROOT_MARKER=${x#*=}
 		;;
+		httpboot=*)
+			HTTPBOOT=1
+			HTTPBOOT_URL=${x#*=}
+		;;
 		# Start livecd loop, looptype options
 		loop=*)
 			LOOP=${x#*=}
@@ -731,6 +735,15 @@ if [ "${CDROOT}" = '1' ]
 then
 	# Setup the root filesystem
 	bootstrapFS
+
+	if [ "${HTTPBOOT}" = '1' ]; then
+		[ ! -d "${ISO_TEMP}" ] && mkdir -p "${ISO_TEMP}"
+		good_msg "Fetching ISO from ${HTTPBOOT_URL}"
+		run wget "${HTTPBOOT_URL}" -O "${ISO_PATH}${ISO_NAME}" -q && good_msg "Written to ${ISO_PATH}${ISO_NAME}"
+		good_msg "Mounting ${ISO_PATH}${ISO_NAME} in ${CDROOT_PATH}"
+		run mount -o ro,loop "${ISO_PATH}${ISO_NAME}" "${CDROOT_PATH}" && good_msg "Mounted ${ISO_PATH}${ISO_NAME} in ${CDROOT_PATH}"
+		got_good_root=1
+	fi
 
 	if [ "${aufs}" = '1' ]
 	then


### PR DESCRIPTION
Usage:

LABEL gentoo-httpboot
  MENU LABEL    ^Boot Gentoo ISO over HTTP
  KERNEL        path/to/gentoo/kernel
  APPEND        initrd=path/to/initrd root=/dev/ram0 init=/linuxrc ip=dhcp cdroot real_root=/mnt/livecd httpboot=http://10.0.0.1/gentoo.iso

Author:        DanF <44616e46@gmail.com>
Signed-off-by: DanF <44616e46@gmail.com>