### PR TITLE
gen_moddeps.sh fixes: drop echo/printf from cycle && introduce xbasename() && fix including extra modules

### DIFF
--- a/gen_moddeps.sh
+++ b/gen_moddeps.sh
@@ -27,7 +27,7 @@ gen_dep_list() {
 	if isTrue "${ALLRAMDISKMODULES}"
 	then
 		cat "${moddir}/modules.builtin"
-		cat "${moddir}/modules.order"
+		cat "${moddir}/modules.dep" | cut -d':' -f1
 	else
 		local -a modlist=() moddeplist=()
 

--- a/gen_moddeps.sh
+++ b/gen_moddeps.sh
@@ -10,6 +10,17 @@ mod_dep_list() {
 	cat "${TEMP}/moddeps"
 }
 
+xbasename() {
+	local -a moddeplist=( $( </dev/stdin ) )
+
+	if (( ${#moddeplist[@]} > 0 ))
+	then
+		# prepend slash to each moddeplist element
+		# to avoid passing elements as basename options
+		basename -s "${KEXT}" "${moddeplist[@]/#/\/}"
+	fi
+}
+
 gen_dep_list() {
 	local moddir="${KERNEL_MODULES_PREFIX%/}/lib/modules/${KV}"
 
@@ -60,5 +71,5 @@ gen_dep_list() {
 		)
 
 		printf '%s\n' "${moddeplist[@]}"
-	fi | xargs basename -s "${KEXT}" | sort | uniq
+	fi | xbasename | sort | uniq
 }

--- a/gen_moddeps.sh
+++ b/gen_moddeps.sh
@@ -18,7 +18,7 @@ gen_dep_list() {
 		cat "${moddir}/modules.builtin"
 		cat "${moddir}/modules.order"
 	else
-		local -a modlist=()
+		local -a modlist=() moddeplist=()
 
 		local mygroups
 		for mygroups in ${!MODULES_*} GK_INITRAMFS_ADDITIONAL_KMODULES
@@ -44,8 +44,7 @@ gen_dep_list() {
 		local mydeps mymod
 		while IFS=" " read -r -u 3 mymod mydeps
 		do
-			echo ${mymod%:}
-			printf '%s\n' ${mydeps}
+			moddeplist+=( ${mymod%:} ${mydeps} )
 		done 3< <(
 			local -a rxargs=( "${modlist[@]}" )
 
@@ -59,5 +58,7 @@ gen_dep_list() {
 			cat "${moddir}/modules.dep" \
 				| grep -F "${rxargs[@]}"
 		)
+
+		printf '%s\n' "${moddeplist[@]}"
 	fi | xargs basename -s "${KEXT}" | sort | uniq
 }


### PR DESCRIPTION
```
gen_moddeps.sh: don't use echo/printf inside the cycle

Also prevent printing empty line if mydeps column is null.

Signed-off-by: Dmitry Baranov <reagentoo@gmail.com>
```
```
gen_moddeps.sh: introduce xbasename()

Introduce xbasename() wrapper to use it instead of xargs basename.
It guards from two cases:
- zero count of module names is passing from pipe
- module name starting with "-" interprets as option

Signed-off-by: Dmitry Baranov <reagentoo@gmail.com>
```
```
gen_moddeps.sh: fix including extra modules when ALLRAMDISKMODULES="yes"

depmod util doesn't care about updating modules.order
when the new extra modules was installed.

Bug: https://bugs.gentoo.org/916233
Signed-off-by: Dmitry Baranov <reagentoo@gmail.com>
```