### PR TITLE
manpage: add example for crypt_root and crypt_swap options

### DIFF
--- a/doc/genkernel.8.txt
+++ b/doc/genkernel.8.txt
@@ -689,7 +689,8 @@ recognized by the kernel itself.
 *crypt_root_options*=<...>::
     This specifies additional options, which should get passed to
     cryptsetup when opening root volume. Can be specified multiple
-    times or separate multiple options with a comma.
+    times or separate multiple options with a comma, for example
+    '--perf-no_read_workqueue,--perf-no_write_workqueue'.
 
 *crypt_swap*=<...>::
     This specifies the swap device encrypted by LUKS.
@@ -697,7 +698,8 @@ recognized by the kernel itself.
 *crypt_swap_options*=<...>::
     This specifies additional options, which should get passed to
     cryptsetup when opening swap volume. Can be specified multiple
-    times or separate multiple options with a comma.
+    times or separate multiple options with a comma, for example
+    '--perf-no_read_workqueue,--perf-no_write_workqueue'.
 
 *root_header*=<...>::
     In case your encrypted root uses a LUKS detached header, you can


### PR DESCRIPTION
I am opening this PR to add an example in the commit mentioned options to clarify possible confusion for future users, as it wasn't  clear that I had to specify "--option,--option2", instead of "option1,option2" (for example, in mkinitcpio they use the latter system, specifically `cryptdevice=device:dmname:option1,option2`)