### PR TITLE
gen_moddeps.sh with ALLFIRMWARE="no": always include firmware for built-in modules

### DIFF
--- a/gen_moddeps.sh
+++ b/gen_moddeps.sh
@@ -62,13 +62,12 @@ gen_dep_list() {
 			rxargs=( "${rxargs[@]/#/-e\/}" )
 			rxargs=( "${rxargs[@]/%/${KEXT}:}" )
 
-			cat "${moddir}/modules.builtin" \
-				| xargs printf '%s:\n' \
-				| grep -F "${rxargs[@]}"
-
 			cat "${moddir}/modules.dep" \
 				| grep -F "${rxargs[@]}"
 		)
+
+		# Always include firmware for built-in modules
+		cat "${moddir}/modules.builtin"
 
 		printf '%s\n' "${moddeplist[@]}"
 	fi | xbasename | sort | uniq


### PR DESCRIPTION
With the radeon module built-in into the kernel and ALLFIRMWARE="no" I get a black screen after boot due to missing GPU firmware.

The issue here is that built-in modules do not occur in the "modules.dep" file so they won't be caught by the dependency scanning loop in gen_dep_list().

They need to be manually added to the module list - do that unconditionally, since if a user wanted some module built-in into the kernel they definitely expect it to work properly at boot.