### PR TITLE
Fix modinfo error

### DIFF
--- a/gen_configkernel.sh
+++ b/gen_configkernel.sh
@@ -25,6 +25,7 @@ determine_kernel_config_file() {
 		local -a kconfig_candidates
 
 		local -a gk_kconfig_candidates
+		gk_kconfig_candidates+=( "${KERNEL_MODULES_PREFIX%/}/lib/modules/${KV}/source/.config" )
 		gk_kconfig_candidates+=( "${GK_SHARE}/arch/${ARCH}/kernel-config-${KV}" )
 		gk_kconfig_candidates+=( "${GK_SHARE}/arch/${ARCH}/kernel-config-${VER}.${PAT}" )
 		gk_kconfig_candidates+=( "${GK_SHARE}/arch/${ARCH}/generated-config" )

--- a/gen_funcs.sh
+++ b/gen_funcs.sh
@@ -2054,6 +2054,40 @@ expand_file() {
 	echo "${expanded_file}"
 }
 
+find_and_unpack() {
+	local flist
+
+	local fmt
+	for fmt in "$@"
+	do
+		case "${fmt}" in
+		"gz"|"xz"|"zstd")
+			flist=( $(find -type f -name "*.${fmt}") )
+			;;
+		*)
+			gen_die "unknown compression format: ${fmt}"
+			;;
+		esac
+
+		if [ ${#flist[@]} -lt 1 ]
+		then
+			continue
+		fi
+
+		case "${fmt}" in
+		"gz")
+			gunzip "${flist[@]}"
+			;;
+		"xz")
+			unxz "${flist[@]}"
+			;;
+		"zstd")
+			unzstd "${flist[@]}"
+			;;
+		esac
+	done
+}
+
 find_kernel_binary() {
 	local kernel_binary=${*}
 	local kernel_binary_found=

--- a/gen_initramfs.sh
+++ b/gen_initramfs.sh
@@ -1923,7 +1923,7 @@ append_modules() {
 
 		if [ ! -f "${mymod}" ]
 		then
-			gen_die "Module '${i}${KEXT}' is missing!"
+			gen_die "Module '${mymod}' is missing!"
 		fi
 
 		modlist+=( "${mymod/#${modules_srcdir}\//}" )

--- a/gen_initramfs.sh
+++ b/gen_initramfs.sh
@@ -1806,6 +1806,10 @@ append_firmware() {
 		cp -rL --parents --target-directory="${TDIR}/lib/firmware" "${fwlist[@]}" 2>/dev/null \
 			|| gen_die "Failed to copy firmware files to '${TDIR}/lib/firmware'!"
 		popd &>/dev/null || gen_die "Failed to chdir!"
+
+		pushd "${TDIR}/lib/firmware" &>/dev/null || gen_die "Failed to chdir to '${TDIR}/lib/firmware'!"
+		find_and_unpack xz zstd
+		popd &>/dev/null || gen_die "Failed to chdir!"
 	fi
 
 	cd "${TDIR}" || gen_die "Failed to chdir to '${TDIR}'!"
@@ -1939,6 +1943,10 @@ append_modules() {
 
 	cp -ax --parents --target-directory "${modules_dstdir}" modules* 2>/dev/null \
 		|| gen_die "Failed to copy '${modules_srcdir}/modules*' to '${modules_dstdir}'!"
+
+	pushd "${modules_dstdir}" &>/dev/null || gen_die "Failed to chdir to '${modules_dstdir}'!"
+	find_and_unpack gz xz zstd
+	popd &>/dev/null || gen_die "Failed to chdir!"
 
 	print_info 2 "$(get_indent 2)modules: Updating modules.dep ..."
 	local depmod_cmd=( depmod -a -b "${TDIR}" ${KV} )

--- a/gen_moddeps.sh
+++ b/gen_moddeps.sh
@@ -62,13 +62,12 @@ gen_dep_list() {
 			rxargs=( "${rxargs[@]/#/-e\/}" )
 			rxargs=( "${rxargs[@]/%/${KEXT}:}" )
 
-			cat "${moddir}/modules.builtin" \
-				| xargs printf '%s:\n' \
-				| grep -F "${rxargs[@]}"
-
 			cat "${moddir}/modules.dep" \
 				| grep -F "${rxargs[@]}"
 		)
+
+		# Always include firmware for built-in modules
+		cat "${moddir}/modules.builtin"
 
 		printf '%s\n' "${moddeplist[@]}"
 	fi | xbasename | sort | uniq


### PR DESCRIPTION
```
gen_moddeps.sh: always include firmware for built-in modules with ALLFIRMWARE="no"

These do not occur in the "modules.dep" file so they won't be caught by the
dependency scanning loop in gen_dep_list() - they need to be manually added
to the module list.

Closes: #54
Signed-off-by: Maciej S. Szmigiero <mail@maciej.szmigiero.name>
```
```
gen_moddeps.sh: use KEXT along with default '.ko' extension to prevent modinfo error

Also improved gen_dep_list() and get rid xbasename()

Bug: https://bugs.gentoo.org/922663
Closes: #57
Signed-off-by: Dmitriy Baranov <reagentoo@gmail.com>
```
```
gen_initramfs.sh: copy compressed firmwares

Signed-off-by: Dmitriy Baranov <reagentoo@gmail.com>
```
```
gen_initramfs.sh: unpack compressed modules/firmwares to reduce image size

Signed-off-by: Dmitriy Baranov <reagentoo@gmail.com>
```
```
gen_initramfs.sh: fix gen_die message in append_modules()

Signed-off-by: Dmitriy Baranov <reagentoo@gmail.com>
```
```
gen_configkernel.sh: add priority kernel config in determine_kernel_config_file()

This is useful for building an image with sys-kernel/gentoo-kernel.

Signed-off-by: Dmitriy Baranov <reagentoo@gmail.com>
```