### PR TITLE
build: fix for POSIX shells

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ SOFTWARE = BCACHE_TOOLS \
 	ZLIB \
 	ZSTD
 
-SOFTWARE_VERSION = $(foreach entry, $(SOFTWARE), "VERSION_$(entry)=${VERSION_$(entry)}\n")
+SOFTWARE_VERSION = $(foreach entry, $(SOFTWARE), "VERSION_$(entry)=${VERSION_$(entry)}")
 
 PREFIX = /usr/local
 BINDIR = $(PREFIX)/bin
@@ -183,7 +183,7 @@ $(BUILD_DIR)/build-config:
 
 $(BUILD_DIR)/software.sh:
 	install -d $(BUILD_DIR)/temp/
-	echo -e $(SOFTWARE_VERSION) > $(BUILD_DIR)/temp/versions
+	printf '%s\n' $(SOFTWARE_VERSION) > $(BUILD_DIR)/temp/versions
 	cat $(BUILD_DIR)/temp/versions defaults/software.sh > $(BUILD_DIR)/software.sh
 
 $(BUILD_DIR)/doc/genkernel.8.txt:


### PR DESCRIPTION
When building genkernel where /bin/sh is a POSIX shell such as lksh (mksh) it will install a malformed software.sh. This is because 'echo -e' is not portable shell. This can be fixed by using 'printf' instead.