### PR TITLE
Several musl build fixes.

### DIFF
--- a/patches/eudev/3.2.14/eudev-3.2.14-static.patch
+++ b/patches/eudev/3.2.14/eudev-3.2.14-static.patch
@@ -1,14 +1,14 @@
 --- a/configure.ac
 +++ b/configure.ac
-@@ -261,7 +261,7 @@ AC_ARG_ENABLE(kmod, AS_HELP_STRING([--disable-kmod], [disable loadable modules s
+@@ -252,7 +252,7 @@ AC_ARG_ENABLE(kmod, AS_HELP_STRING([--disable-kmod], [disable loadable modules s
  if test "x$enable_kmod" != "xno"; then
-         PKG_CHECK_EXISTS([ libkmod ], have_kmod=yes, have_kmod=no)
-         if test "x$have_kmod" = "xyes"; then
--                PKG_CHECK_MODULES(KMOD, [ libkmod >= 15 ],
-+                PKG_CHECK_MODULES_STATIC(KMOD, [ libkmod >= 15 ],
-                         [AC_DEFINE(HAVE_KMOD, 1, [Define if kmod is available])],
-                         AC_MSG_ERROR([*** kmod version >= 15 not found]))
-         fi
+ 	PKG_CHECK_EXISTS([ libkmod ], have_kmod=yes, have_kmod=no)
+ 	if test "x$have_kmod" = "xyes"; then
+-		PKG_CHECK_MODULES(KMOD, [ libkmod >= 15 ],
++		PKG_CHECK_MODULES_STATIC(KMOD, [ libkmod >= 15 ],
+ 			[AC_DEFINE(HAVE_KMOD, 1, [Define if kmod is available])],
+ 			AC_MSG_ERROR([*** kmod version >= 15 not found]))
+ 	fi
 --- a/src/ata_id/Makefile.am
 +++ b/src/ata_id/Makefile.am
 @@ -11,6 +11,8 @@ udevlibexec_PROGRAMS = \
@@ -94,4 +94,3 @@
  v4l_id_LDADD = \
  	$(top_builddir)/src/libudev/libudev-private.la \
  	$(top_builddir)/src/udev/libudev-core.la
- 

--- a/patches/kmod/31/kmod-31-musl-basename.patch
+++ b/patches/kmod/31/kmod-31-musl-basename.patch
@@ -1,0 +1,113 @@
+https://github.com/kmod-project/kmod/pull/32
+
+From 721ed6040c7aa47070faf6378c433089e178bd43 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Sat, 9 Dec 2023 17:35:59 -0800
+Subject: [PATCH] Use portable implementation for basename API
+
+musl has removed the non-prototype declaration of basename from
+string.h [1] which now results in build errors with clang-17+ compiler
+
+Implement GNU basename behavior using strchr which is portable across libcs
+
+Fixes
+../git/tools/kmod.c:71:19: error: call to undeclared function 'basename'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
+71 | "Commands:\n", basename(argv[0]));
+| ^
+
+[1] https://git.musl-libc.org/cgit/musl/commit/?id=725e17ed6dff4d0cd22487bb64470881e86a92e7
+
+Suggested-by: Rich Felker
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+--- a/libkmod/libkmod-config.c
++++ b/libkmod/libkmod-config.c
+@@ -794,7 +794,7 @@ static int conf_files_insert_sorted(struct kmod_ctx *ctx,
+ 	bool is_single = false;
+ 
+ 	if (name == NULL) {
+-		name = basename(path);
++		name = gnu_basename(path);
+ 		is_single = true;
+ 	}
+ 
+--- a/shared/util.c
++++ b/shared/util.c
+@@ -172,9 +172,9 @@ char *modname_normalize(const char *modname, char buf[static PATH_MAX], size_t *
+ 
+ char *path_to_modname(const char *path, char buf[static PATH_MAX], size_t *len)
+ {
+-	char *modname;
++	const char *modname;
+ 
+-	modname = basename(path);
++	modname = gnu_basename(path);
+ 	if (modname == NULL || modname[0] == '\0')
+ 		return NULL;
+ 
+--- a/shared/util.h
++++ b/shared/util.h
+@@ -5,6 +5,7 @@
+ #include <stdbool.h>
+ #include <stdlib.h>
+ #include <stdio.h>
++#include <string.h>
+ #include <sys/types.h>
+ #include <sys/stat.h>
+ #include <time.h>
+@@ -76,6 +77,12 @@ do {						\
+ 	__p->__v = (val);			\
+ } while(0)
+ 
++static _always_inline_ const char *gnu_basename(const char *s)
++{
++  const char *p = strrchr(s, '/');
++  return p ? p+1 : s;
++}
++
+ static _always_inline_ unsigned int ALIGN_POWER2(unsigned int u)
+ {
+ 	return 1 << ((sizeof(u) * 8) - __builtin_clz(u - 1));
+--- a/testsuite/testsuite.c
++++ b/testsuite/testsuite.c
+@@ -70,7 +70,7 @@ static void help(void)
+ 
+ 	printf("Usage:\n"
+ 	       "\t%s [options] <test>\n"
+-	       "Options:\n", basename(progname));
++	       "Options:\n", gnu_basename(progname));
+ 
+ 	for (itr = options, itr_short = options_short;
+ 				itr->name != NULL; itr++, itr_short++)
+--- a/tools/depmod.c
++++ b/tools/depmod.c
+@@ -762,7 +762,7 @@ static int cfg_files_insert_sorted(struct cfg_file ***p_files, size_t *p_n_files
+ 	if (name != NULL)
+ 		namelen = strlen(name);
+ 	else {
+-		name = basename(dir);
++		name = gnu_basename(dir);
+ 		namelen = strlen(name);
+ 		dirlen -= namelen + 1;
+ 	}
+--- a/tools/kmod.c
++++ b/tools/kmod.c
+@@ -68,7 +68,7 @@ static int kmod_help(int argc, char *argv[])
+ 			"Options:\n"
+ 			"\t-V, --version     show version\n"
+ 			"\t-h, --help        show this help\n\n"
+-			"Commands:\n", basename(argv[0]));
++			"Commands:\n", gnu_basename(argv[0]));
+ 
+ 	for (i = 0; i < ARRAY_SIZE(kmod_cmds); i++) {
+ 		if (kmod_cmds[i]->help != NULL) {
+@@ -156,7 +156,7 @@ static int handle_kmod_compat_commands(int argc, char *argv[])
+ 	const char *cmd;
+ 	size_t i;
+ 
+-	cmd = basename(argv[0]);
++	cmd = gnu_basename(argv[0]);
+ 
+ 	for (i = 0; i < ARRAY_SIZE(kmod_compat_cmds); i++) {
+ 		if (streq(kmod_compat_cmds[i]->name, cmd))
+

--- a/patches/lvm/2.03.22/lvm2-019-musl-basename.patch
+++ b/patches/lvm/2.03.22/lvm2-019-musl-basename.patch
@@ -1,0 +1,34 @@
+https://bugs.gentoo.org/937239
+https://github.com/lvmteam/lvm2/commit/f98d2ffe8753895c84160a7abce4223bd127cd9e
+
+From f98d2ffe8753895c84160a7abce4223bd127cd9e Mon Sep 17 00:00:00 2001
+From: Zdenek Kabelac <zkabelac@redhat.com>
+Date: Wed, 27 Mar 2024 00:28:14 +0100
+Subject: [PATCH] device_id: use dm_basename
+
+Avoid problems for other libc like muslc and use dm_basename.
+
+Prototype for basename has been removed from string.h from latest musl [1]
+compilers e.g. clang-18 flags the absense of prototype as error. therefore
+include libgen.h for providing it.
+
+[1] https://git.musl-libc.org/cgit/musl/commit/?id=725e17ed6dff4d0cd22487bb64470881e86a92e7
+
+Reported-by: Khem Raj <raj.khem@gmail.com>
+---
+ lib/device/device_id.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/device/device_id.c b/lib/device/device_id.c
+index 7d67a1cb7..200d39432 100644
+--- a/lib/device/device_id.c
++++ b/lib/device/device_id.c
+@@ -740,7 +740,7 @@ static int _dev_read_sys_serial(struct cmd_context *cmd, struct device *dev,
+ 		int ret;
+ 
+ 		/* /dev/vda to vda */
+-		base = basename(devname);
++		base = dm_basename(devname);
+ 
+ 		/* vda1 to vda */
+ 		for (i = 0; i < strlen(base); i++) {

--- a/patches/lvm/2.03.22/lvm2-020-freopen-musl.patch
+++ b/patches/lvm/2.03.22/lvm2-020-freopen-musl.patch
@@ -1,0 +1,54 @@
+From 4cf08811e112100a2b10c60047f3c537ad21d674 Mon Sep 17 00:00:00 2001
+From: David Seifert <soap@gentoo.org>
+Date: Sat, 28 Jan 2023 14:22:42 +0100
+Subject: [PATCH] Use `freopen()` on {stdin,stdout,stderr}
+
+* ISO C does not guarantee that the standard streams are modifiable
+  lvalues. Glibc even calls out this behaviour as non-portable:
+    https://www.gnu.org/software/libc/manual/html_node/Standard-Streams.html
+--- a/lib/log/log.c
++++ b/lib/log/log.c
+@@ -208,7 +208,11 @@ int reopen_standard_stream(FILE **stream, const char *mode)
+ 
+ 	_check_and_replace_standard_log_streams(old_stream, new_stream);
+ 
++#ifdef __GLIBC__
+ 	*stream = new_stream;
++#else
++	freopen(NULL, mode, *stream);
++#endif
+ 	return 1;
+ }
+ 
+--- a/tools/lvmcmdline.c
++++ b/tools/lvmcmdline.c
+@@ -3422,7 +3422,7 @@ static int _check_standard_fds(void)
+ 	int err = is_valid_fd(STDERR_FILENO);
+ 
+ 	if (!is_valid_fd(STDIN_FILENO) &&
+-	    !(stdin = fopen(_PATH_DEVNULL, "r"))) {
++	    !freopen(_PATH_DEVNULL, "r", stdin)) {
+ 		if (err)
+ 			perror("stdin stream open");
+ 		else
+@@ -3432,7 +3432,7 @@ static int _check_standard_fds(void)
+ 	}
+ 
+ 	if (!is_valid_fd(STDOUT_FILENO) &&
+-	    !(stdout = fopen(_PATH_DEVNULL, "w"))) {
++	    !freopen(_PATH_DEVNULL, "w", stdout)) {
+ 		if (err)
+ 			perror("stdout stream open");
+ 		/* else no stdout */
+@@ -3440,7 +3440,7 @@ static int _check_standard_fds(void)
+ 	}
+ 
+ 	if (!is_valid_fd(STDERR_FILENO) &&
+-	    !(stderr = fopen(_PATH_DEVNULL, "w"))) {
++	    !freopen(_PATH_DEVNULL, "w", stderr)) {
+ 		printf("stderr stream open: %s\n",
+ 		       strerror(errno));
+ 		return 0;
+-- 
+2.39.2
+


### PR DESCRIPTION
* Add missing musl patches for lvm from `::gentoo`.
Gentoo Issue: https://bugs.gentoo.org/934773
* Add missing musl patch for kmod from `::gentoo`.
* Bump eudev to `v3.2.14` which is a version that compiles with musl.
The patch was rebased for this version.